### PR TITLE
Fix wrong usage of CompositeDisposable

### DIFF
--- a/app/src/main/java/de/czyrux/store/ui/base/BaseActivity.java
+++ b/app/src/main/java/de/czyrux/store/ui/base/BaseActivity.java
@@ -28,7 +28,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override
     public void onStop() {
         super.onStop();
-        disposables.dispose();
+        disposables.clear();
     }
 
     @Override

--- a/app/src/main/java/de/czyrux/store/ui/base/BaseFragment.java
+++ b/app/src/main/java/de/czyrux/store/ui/base/BaseFragment.java
@@ -36,7 +36,7 @@ public abstract class BaseFragment extends Fragment {
     @Override
     public void onStop() {
         super.onStop();
-        disposables.dispose();
+        disposables.clear();
     }
 
     protected final void addDisposable(Disposable disposable) {


### PR DESCRIPTION
Before, dispose was used on Fragment#onStop, which made impossible to attach new disposable afterwards. Now clear is used instead

Fixes #33 